### PR TITLE
Support Windows wallpaper executable packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # WP
+
+## Packaging into a standalone Windows executable
+
+1. Ensure Python 3.11+ and pip are installed on the build machine.
+2. Install PyInstaller: `pip install pyinstaller`.
+3. From this directory run `pyinstaller --clean --noconsole --onefile --name SetRandomWallpaper set_random_wallpaper.py`.
+
+The resulting executable (`dist/SetRandomWallpaper.exe`) can be copied next to the
+`WP` folder on the target Windows machine. Because the Python interpreter is
+embedded by PyInstaller, the executable works without requiring Python to be
+installed on the device. Each launch copies a random file from the neighbouring
+`WP` directory into the user's Documents folder and applies it as the desktop
+wallpaper.

--- a/build_windows_exe.ps1
+++ b/build_windows_exe.ps1
@@ -1,0 +1,5 @@
+param(
+    [string]$OutputName = "SetRandomWallpaper"
+)
+
+pyinstaller --clean --noconsole --onefile --name $OutputName set_random_wallpaper.py

--- a/set_random_wallpaper.py
+++ b/set_random_wallpaper.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Set the desktop wallpaper from a random file in the sibling ``WP`` directory.
+
+The script copies the randomly chosen file into the user's Documents folder before
+applying it as the desktop background. On Windows the wallpaper is applied via the
+``SystemParametersInfoW`` Win32 API. On GNOME-based systems ``gsettings`` is used.
+
+When packaged with PyInstaller the executable can be distributed without requiring a
+Python installation on the target machine.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import random
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SPI_SETDESKWALLPAPER = 20
+SPIF_UPDATEINIFILE = 0x01
+SPIF_SENDWININICHANGE = 0x02
+
+
+def resolve_base_dir() -> Path:
+    """Return the directory containing the script or frozen executable."""
+
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return Path(__file__).resolve().parent
+
+
+def choose_random_file(folder: Path) -> Path:
+    files = [path for path in folder.iterdir() if path.is_file()]
+    if not files:
+        raise FileNotFoundError(
+            f"No files found in '{folder}'. Add at least one file to continue."
+        )
+    return random.choice(files)
+
+
+def copy_to_documents(source: Path) -> Path:
+    documents_dir = Path.home() / "Documents"
+    documents_dir.mkdir(parents=True, exist_ok=True)
+
+    destination = documents_dir / source.name
+    shutil.copy2(source, destination)
+    return destination
+
+
+def set_wallpaper_windows(image_path: Path) -> None:
+    result = ctypes.windll.user32.SystemParametersInfoW(  # type: ignore[attr-defined]
+        SPI_SETDESKWALLPAPER,
+        0,
+        str(image_path),
+        SPIF_UPDATEINIFILE | SPIF_SENDWININICHANGE,
+    )
+    if result == 0:
+        raise RuntimeError("Failed to set wallpaper using the Win32 API.")
+
+
+def set_wallpaper_gnome(image_path: Path) -> None:
+    wallpaper_uri = image_path.as_uri()
+    for schema_key in ("picture-uri", "picture-uri-dark"):
+        try:
+            subprocess.run(
+                [
+                    "gsettings",
+                    "set",
+                    "org.gnome.desktop.background",
+                    schema_key,
+                    wallpaper_uri,
+                ],
+                check=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            raise RuntimeError(
+                "Failed to set wallpaper using gsettings. "
+                "Ensure GNOME is installed and accessible."
+            ) from exc
+
+
+def set_wallpaper(image_path: Path) -> None:
+    if sys.platform.startswith("win"):
+        set_wallpaper_windows(image_path)
+    else:
+        set_wallpaper_gnome(image_path)
+
+
+def main() -> None:
+    base_dir = resolve_base_dir()
+    source_dir = base_dir / "WP"
+    if not source_dir.is_dir():
+        raise FileNotFoundError(f"Folder '{source_dir}' was not found")
+
+    chosen_file = choose_random_file(source_dir)
+    destination = copy_to_documents(chosen_file)
+
+    set_wallpaper(destination)
+    print(f"Wallpaper set to {destination}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update the wallpaper utility to support Windows via the SystemParametersInfo Win32 API while keeping GNOME support
- add PyInstaller-friendly path resolution so the program works when frozen as an executable
- document how to build a standalone Windows executable and provide a helper PowerShell script

## Testing
- not run (script-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e61b6198088331aca8e7c3f3979289